### PR TITLE
Add option to not steal focus when alert appears

### DIFF
--- a/SelfCare/Configuration.cs
+++ b/SelfCare/Configuration.cs
@@ -30,6 +30,8 @@ namespace SelfCare {
 		public bool DisableInCombat = true;
 		public bool DisableInCutscene = true;
 
+		public bool NoFocusOnAppearing = true;
+
 		public bool PrintToChat = true;
 
 		public UiColor BgColor = new(ImGuiCol.WindowBg);

--- a/SelfCare/Interface/AlertWindow.cs
+++ b/SelfCare/Interface/AlertWindow.cs
@@ -32,6 +32,10 @@ namespace SelfCare.Interface {
 			if ((IsConfiguring && noMove != 0) || (!IsConfiguring && noMove == 0))
 				Flags ^= ImGuiWindowFlags.NoMove;
 
+			var noFocus = Flags & ImGuiWindowFlags.NoFocusOnAppearing;
+			if ((SelfCare.Config.NoFocusOnAppearing && noFocus == 0) || (!SelfCare.Config.NoFocusOnAppearing && noFocus != 0))
+				Flags ^= ImGuiWindowFlags.NoFocusOnAppearing;
+
 			var canOpen = Services.ClientState.IsLoggedIn;
 			ShouldHide = !canOpen;
 

--- a/SelfCare/Interface/ConfigWindow.cs
+++ b/SelfCare/Interface/ConfigWindow.cs
@@ -109,6 +109,10 @@ namespace SelfCare.Interface {
 
 			ImGui.Checkbox("Disabled in combat", ref Config.DisableInCombat);
 
+			ImGui.Spacing();
+
+			ImGui.Checkbox("Don't steal focus when alert appears", ref Config.NoFocusOnAppearing);
+
 			// Print to chat
 
 			ImGui.Spacing();


### PR DESCRIPTION
Fixes #2

When an alert fires while the user is typing in chat or any other text input (e.g. chat2, other Dalamud plugins), the alert window grabs keyboard focus and interrupts input.

This adds `NoFocusOnAppearing` to the alert window's ImGui flags so the window no longer steals focus when it pops up. A toggle has also been added to the General settings tab ("Don't steal focus when alert appears") so users can opt out of this behaviour if preferred. It is enabled by default.
